### PR TITLE
blueprint: Use new constructor format

### DIFF
--- a/slackin.js
+++ b/slackin.js
@@ -6,7 +6,9 @@ const { Container, publicInternet, allowTraffic } = require('kelda');
  * accessible.
  */
 function createSlackinContainer(slackTeamId, slackToken, port = 80) {
-  const slackin = new Container('slackin', 'keldaio/slackin', {
+  const slackin = new Container({
+    name: 'slackin',
+    image: 'keldaio/slackin',
     command: ['slackin', '--port', port.toString()],
     env: {
       SLACK_SUBDOMAIN: slackTeamId,

--- a/slackinExample.js
+++ b/slackinExample.js
@@ -12,6 +12,6 @@ const slackinContainer = slackin.createSlackinContainer(slackTeam, slackToken);
 allowTraffic(publicInternet, slackinContainer, 80);
 
 const machine = new Machine({ provider: 'Amazon', size: 't2.micro' });
-const infra = new Infrastructure(machine, machine);
+const infra = new Infrastructure({ masters: machine, workers: machine });
 
 slackinContainer.deploy(infra);


### PR DESCRIPTION
The build will fail until the next release of Kelda (0.10.0). This should not be merged until then.